### PR TITLE
Temp Workaround: System.IO.Compression fix

### DIFF
--- a/animated-vector-drawable/nuget/Xamarin.Android.Support.Animated.Vector.Drawable.nuspec
+++ b/animated-vector-drawable/nuget/Xamarin.Android.Support.Animated.Vector.Drawable.nuspec
@@ -18,6 +18,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.Animated.Vector.Drawable.dll" target="lib\MonoAndroid403" />
+    <file src="output/Xamarin.Android.Support.Animated.Vector.Drawable.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/build.cake
+++ b/build.cake
@@ -1,10 +1,10 @@
 #tool nuget:?package=ILRepack&version=2.0.10
-#tool nuget:?package=XamarinComponent&version=1.1.0.29
+#tool nuget:?package=XamarinComponent
 
-#addin nuget:?package=Cake.XCode&version=1.0.4.0
-#addin nuget:?package=Cake.Xamarin&version=1.3.0.1
-#addin nuget:?package=Cake.Xamarin.Build&version=1.0.11.0
-#addin nuget:?package=Cake.FileHelpers&version=1.0.3.2
+#addin nuget:?package=Cake.XCode
+#addin nuget:?package=Cake.Xamarin
+#addin nuget:?package=Cake.Xamarin.Build
+#addin nuget:?package=Cake.FileHelpers
 
 var TARGET = Argument ("t", Argument ("target", "Default"));
 
@@ -268,7 +268,7 @@ Task ("component-docs").Does (() =>
 	foreach (var compDir in componentDirs) {
 
 		var f = compDir.CombineWithFilePath ("./component/GettingStarted.template.md");
-		
+
 		if (!FileExists (f))
 			continue;
 
@@ -300,7 +300,7 @@ Task ("component-docs").Does (() =>
 	foreach (var compDir in componentDirs) {
 
 		var f = compDir.CombineWithFilePath ("./component/Details.template.md");
-		
+
 		if (!FileExists (f))
 			continue;
 

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,10 @@ TOOLS_DIR=$SCRIPT_DIR/tools
 NUGET_EXE=$TOOLS_DIR/nuget.exe
 CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
 
+# BEGIN TEMP WORKAROUND
+SYSIOCOMP=$TOOLS_DIR/System.IO.Compression.dll
+# END TEMP WORKAROUND
+
 # Define default arguments.
 SCRIPT="build.cake"
 TARGET="Default"
@@ -68,6 +72,20 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 popd >/dev/null
+
+# BEGIN TEMP WORKAROUND
+# There is a bug in Mono's System.IO.Compression
+# This binary fixes the bug for now
+# Download System.IO.Compression if it does not exist.
+if [ ! -f "$SYSIOCOMP" ]; then
+    echo "Downloading System.IO.Compression.dll ..."
+    curl -Lsfo "$SYSIOCOMP" http://xamarin-components-binaries.s3.amazonaws.com/System.IO.Compression.dll
+    if [ $? -ne 0 ]; then
+        echo "An error occured while downloading System.IO.Compression.dll."
+        exit 1
+    fi
+fi
+# END TEMP WORKAROUND
 
 # Make sure that Cake has been installed.
 if [ ! -f "$CAKE_EXE" ]; then

--- a/build.sh
+++ b/build.sh
@@ -52,8 +52,8 @@ fi
 # Download NuGet if it does not exist.
 if [ ! -f "$NUGET_EXE" ]; then
     echo "Downloading NuGet..."
-    # For now grab explicit 2.8.6 version instead of: https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-    curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/v2.8.6/nuget.exe
+    # For now grab explicit 3.4.4 version instead of: https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+    curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/v3.4.4/NuGet.exe
     if [ $? -ne 0 ]; then
         echo "An error occured while downloading nuget.exe."
         exit 1

--- a/customtabs/nuget/Xamarin.Android.Support.CustomTabs.nuspec
+++ b/customtabs/nuget/Xamarin.Android.Support.CustomTabs.nuspec
@@ -17,6 +17,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.CustomTabs.dll" target="lib\MonoAndroid403" />
+    <file src="output/Xamarin.Android.Support.CustomTabs.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/design/nuget/Xamarin.Android.Support.Design.nuspec
+++ b/design/nuget/Xamarin.Android.Support.Design.nuspec
@@ -19,6 +19,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.Design.dll" target="lib\MonoAndroid43" />
+    <file src="output/Xamarin.Android.Support.Design.dll" target="lib/MonoAndroid43" />
   </files>
 </package>

--- a/percent/nuget/Xamarin.Android.Support.Percent.nuspec
+++ b/percent/nuget/Xamarin.Android.Support.Percent.nuspec
@@ -17,6 +17,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.Percent.dll" target="lib\MonoAndroid403" />
+    <file src="output/Xamarin.Android.Support.Percent.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/recommendation/nuget/Xamarin.Android.Support.Recommendation.nuspec
+++ b/recommendation/nuget/Xamarin.Android.Support.Recommendation.nuspec
@@ -17,6 +17,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.Recommendation.dll" target="lib\MonoAndroid50" />
+    <file src="output/Xamarin.Android.Support.Recommendation.dll" target="lib/MonoAndroid50" />
   </files>
 </package>

--- a/v13/nuget/Xamarin.Android.Support.v13.nuspec
+++ b/v13/nuget/Xamarin.Android.Support.v13.nuspec
@@ -17,6 +17,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.v13.dll" target="lib\MonoAndroid403" />
+    <file src="output/Xamarin.Android.Support.v13.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/v14-preference/nuget/Xamarin.Android.Support.v14.Preference.nuspec
+++ b/v14-preference/nuget/Xamarin.Android.Support.v14.Preference.nuspec
@@ -20,6 +20,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.v14.Preference.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Android.Support.v14.Preference.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/v17-leanback/nuget/Xamarin.Android.Support.v17.Leanback.nuspec
+++ b/v17-leanback/nuget/Xamarin.Android.Support.v17.Leanback.nuspec
@@ -18,6 +18,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.v17.Leanback.dll" target="lib\MonoAndroid50" />
+    <file src="output/Xamarin.Android.Support.v17.Leanback.dll" target="lib/MonoAndroid50" />
   </files>
 </package>

--- a/v17-preference-leanback/nuget/Xamarin.Android.Support.v17.Preference.Leanback.nuspec
+++ b/v17-preference-leanback/nuget/Xamarin.Android.Support.v17.Preference.Leanback.nuspec
@@ -22,6 +22,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.v17.Preference.Leanback.dll" target="lib\MonoAndroid50" />
+    <file src="output/Xamarin.Android.Support.v17.Preference.Leanback.dll" target="lib/MonoAndroid50" />
   </files>
 </package>

--- a/v4/nuget/Xamarin.Android.Support.v4.nuspec
+++ b/v4/nuget/Xamarin.Android.Support.v4.nuspec
@@ -14,6 +14,6 @@
     <iconUrl>https://xamarin-component-icons.s3.amazonaws.com/Xamarin.Android.Support.v4.png</iconUrl>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.v4.dll" target="lib\MonoAndroid403" />
+    <file src="output/Xamarin.Android.Support.v4.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/v7-appcompat/nuget/Xamarin.Android.Support.v7.AppCompat.nuspec
+++ b/v7-appcompat/nuget/Xamarin.Android.Support.v7.AppCompat.nuspec
@@ -19,6 +19,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.v7.AppCompat.dll" target="lib\MonoAndroid403" />
+    <file src="output/Xamarin.Android.Support.v7.AppCompat.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/v7-cardview/nuget/Xamarin.Android.Support.v7.CardView.nuspec
+++ b/v7-cardview/nuget/Xamarin.Android.Support.v7.CardView.nuspec
@@ -14,6 +14,6 @@
     <iconUrl>https://xamarin-component-icons.s3.amazonaws.com/Xamarin.Android.Support.v7.CardView.png</iconUrl>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.v7.CardView.dll" target="lib\MonoAndroid403" />
+    <file src="output/Xamarin.Android.Support.v7.CardView.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/v7-gridlayout/nuget/Xamarin.Android.Support.v7.GridLayout.nuspec
+++ b/v7-gridlayout/nuget/Xamarin.Android.Support.v7.GridLayout.nuspec
@@ -17,6 +17,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.v7.GridLayout.dll" target="lib\MonoAndroid403" />
+    <file src="output/Xamarin.Android.Support.v7.GridLayout.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/v7-mediarouter/nuget/Xamarin.Android.Support.v7.MediaRouter.nuspec
+++ b/v7-mediarouter/nuget/Xamarin.Android.Support.v7.MediaRouter.nuspec
@@ -18,6 +18,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.v7.MediaRouter.dll" target="lib\MonoAndroid403" />
+    <file src="output/Xamarin.Android.Support.v7.MediaRouter.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/v7-palette/nuget/Xamarin.Android.Support.v7.Palette.nuspec
+++ b/v7-palette/nuget/Xamarin.Android.Support.v7.Palette.nuspec
@@ -17,6 +17,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.v7.Palette.dll" target="lib\MonoAndroid403" />
+    <file src="output/Xamarin.Android.Support.v7.Palette.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/v7-preference/nuget/Xamarin.Android.Support.v7.Preference.nuspec
+++ b/v7-preference/nuget/Xamarin.Android.Support.v7.Preference.nuspec
@@ -19,6 +19,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.v7.Preference.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Android.Support.v7.Preference.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/v7-recyclerview/nuget/Xamarin.Android.Support.v7.RecyclerView.nuspec
+++ b/v7-recyclerview/nuget/Xamarin.Android.Support.v7.RecyclerView.nuspec
@@ -17,6 +17,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.v7.RecyclerView.dll" target="lib\MonoAndroid403" />
+    <file src="output/Xamarin.Android.Support.v7.RecyclerView.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/v8-renderscript/nuget/Xamarin.Android.Support.v8.RenderScript.nuspec
+++ b/v8-renderscript/nuget/Xamarin.Android.Support.v8.RenderScript.nuspec
@@ -14,6 +14,6 @@
     <iconUrl>https://xamarin-component-icons.s3.amazonaws.com/Xamarin.Android.Support.v8.RenderScript.png</iconUrl>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Support.v8.RenderScript.dll" target="lib\MonoAndroid403" />
+    <file src="output/Xamarin.Android.Support.v8.RenderScript.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/vector-drawable/nuget/Xamarin.Android.Support.Vector.Drawable.nuspec
+++ b/vector-drawable/nuget/Xamarin.Android.Support.Vector.Drawable.nuspec
@@ -21,6 +21,6 @@
     <file src="./vector-drawable/buildtask/bin/Release/Xamarin.Android.Support.Vector.Drawable.targets" target="build" />
     <file src="./vector-drawable/buildtask/bin/Release/Xamarin.Android.Support.Tasks.VectorDrawable.dll" target="build" />
     
-    <file src="output/Xamarin.Android.Support.Vector.Drawable.dll" target="lib\MonoAndroid403" />
+    <file src="output/Xamarin.Android.Support.Vector.Drawable.dll" target="lib/MonoAndroid403" />
   </files>
 </package>


### PR DESCRIPTION
There is a bug in Mono's System.IO.Compression which causes ZipArchive to produce an incorrect .zip file. This results in corrupt .nupkg files which do not properly install in the IDE.
Until the mono bug is fixed, this workaround is needed to build valid .nupkg files