### PR TITLE
Correct .nuspec file for Xamarin.Android.Support.Design library.

### DIFF
--- a/design/nuget/Xamarin.Android.Support.Design.nuspec
+++ b/design/nuget/Xamarin.Android.Support.Design.nuspec
@@ -17,6 +17,7 @@
       
       <dependency id="Xamarin.Android.Support.v7.AppCompat" version="[$version$]"/>
       <dependency id="Xamarin.Android.Support.v7.RecyclerView" version="[$version$]"/>
+      <dependency id="Xamarin.Android.Support.Transition" version="[$version$]"/>
       <!-- Support V4 -->
       <dependency id="Xamarin.Android.Support.Compat" version="[$version$]"/>
       <dependency id="Xamarin.Android.Support.Core.UI" version="[$version$]"/>


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):
Version 25.0.1-rc1.

### Does this change any of the generated binding API's?
No, this PR doesn't change generated binding API.

### Describe your contribution
Correct .nuspec file for Xamarin.Android.Support.Design library.

Add Xamarin.Android.Support.Transition dependency because transition library is required for BottomNavigationView widget.

Without transition library while inflating layout with BottomNavigationView we get java ClassNotFoundException.

`java.lang.ClassNotFoundException: android.support.transition.AutoTransition`