### PR TITLE
insert a space between arguments

### DIFF
--- a/vector-drawable/buildtask/Xamarin.Android.Support.Vector.Drawable.targets
+++ b/vector-drawable/buildtask/Xamarin.Android.Support.Vector.Drawable.targets
@@ -3,7 +3,7 @@
 
   <!-- Adds an argument to the call to aapt to support vectors -->
   <PropertyGroup>
-    <AndroidResgenExtraArgs>$(AndroidResgenExtraArgs)--no-version-vectors</AndroidResgenExtraArgs>
+    <AndroidResgenExtraArgs>$(AndroidResgenExtraArgs) --no-version-vectors</AndroidResgenExtraArgs>
   </PropertyGroup>
 
   <!-- 


### PR DESCRIPTION
For some unknown reason the argument was added one more times recursively during the build and ended up like

--no-version-vectors--no-version-vectors--no-version-vectors

insert a space between arguments may ignore it