### PR TITLE
Setup [assembly: LinkerSafe] for binding projects

### DIFF
--- a/animated-vector-drawable/source/Properties/AssemblyInfo.cs
+++ b/animated-vector-drawable/source/Properties/AssemblyInfo.cs
@@ -20,3 +20,4 @@ using Android.App;
 // if desired. See the Mono documentation for more information about signing.
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/appcompat-v7/source/Properties/AssemblyInfo.cs
+++ b/appcompat-v7/source/Properties/AssemblyInfo.cs
@@ -21,3 +21,4 @@ using Android.App;
 // if desired. See the Mono documentation for more information about signing.
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/arch-core/common/source/Properties/AssemblyInfo.cs
+++ b/arch-core/common/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/arch-lifecycle/common/source/Properties/AssemblyInfo.cs
+++ b/arch-lifecycle/common/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/arch-lifecycle/runtime/source/Properties/AssemblyInfo.cs
+++ b/arch-lifecycle/runtime/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/cardview-v7/source/Properties/AssemblyInfo.cs
+++ b/cardview-v7/source/Properties/AssemblyInfo.cs
@@ -20,3 +20,4 @@ using Android.App;
 // if desired. See the Mono documentation for more information about signing.
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/constraint-layout-solver/source/Properties/AssemblyInfo.cs
+++ b/constraint-layout-solver/source/Properties/AssemblyInfo.cs
@@ -19,3 +19,4 @@ using Android.App;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion ("1.1.0.0")]
+[assembly: Android.LinkerSafe]

--- a/constraint-layout/source/Properties/AssemblyInfo.cs
+++ b/constraint-layout/source/Properties/AssemblyInfo.cs
@@ -19,3 +19,4 @@ using Android.App;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion ("1.1.0.0")]
+[assembly: Android.LinkerSafe]

--- a/customtabs/source/Properties/AssemblyInfo.cs
+++ b/customtabs/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/design/source/Properties/AssemblyInfo.cs
+++ b/design/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/exifinterface/source/Properties/AssemblyInfo.cs
+++ b/exifinterface/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/gridlayout-v7/source/Properties/AssemblyInfo.cs
+++ b/gridlayout-v7/source/Properties/AssemblyInfo.cs
@@ -20,3 +20,4 @@ using Android.App;
 // if desired. See the Mono documentation for more information about signing.
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/leanback-v17/source/Properties/AssemblyInfo.cs
+++ b/leanback-v17/source/Properties/AssemblyInfo.cs
@@ -26,3 +26,4 @@ using Java.Interop;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/mediarouter-v7/source/Properties/AssemblyInfo.cs
+++ b/mediarouter-v7/source/Properties/AssemblyInfo.cs
@@ -20,3 +20,4 @@ using Android.App;
 // if desired. See the Mono documentation for more information about signing.
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/palette-v7/source/Properties/AssemblyInfo.cs
+++ b/palette-v7/source/Properties/AssemblyInfo.cs
@@ -20,3 +20,4 @@ using Android.App;
 // if desired. See the Mono documentation for more information about signing.
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/percent/source/Properties/AssemblyInfo.cs
+++ b/percent/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/preference-leanback-v17/source/Properties/AssemblyInfo.cs
+++ b/preference-leanback-v17/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/preference-v14/source/Properties/AssemblyInfo.cs
+++ b/preference-v14/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/preference-v7/source/Properties/AssemblyInfo.cs
+++ b/preference-v7/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/recommendation/source/Properties/AssemblyInfo.cs
+++ b/recommendation/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/recyclerview-v7/source/Properties/AssemblyInfo.cs
+++ b/recyclerview-v7/source/Properties/AssemblyInfo.cs
@@ -20,3 +20,4 @@ using Android.App;
 // if desired. See the Mono documentation for more information about signing.
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/renderscript-v8/source/Properties/AssemblyInfo.cs
+++ b/renderscript-v8/source/Properties/AssemblyInfo.cs
@@ -25,6 +25,7 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]
 
 [assembly: Java.Interop.JavaLibraryReference (__Consts.RootDir + "/renderscript/lib/renderscript-v8.jar",
 	SourceUrl = __Consts.SupportUrl,

--- a/support-annotations/source/Properties/AssemblyInfo.cs
+++ b/support-annotations/source/Properties/AssemblyInfo.cs
@@ -30,3 +30,4 @@ using Java.Interop;
 // This is needed for compiling javac in apps, but the actual lib is not needed in the app itself
 // only for the compilation stage, so we don't need to actually package it in the app
 [assembly: DoNotPackage ("support-annotations.jar")]
+[assembly: Android.LinkerSafe]

--- a/support-compat/source/Properties/AssemblyInfo.cs
+++ b/support-compat/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/support-core-ui/source/Properties/AssemblyInfo.cs
+++ b/support-core-ui/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/support-core-utils/source/Properties/AssemblyInfo.cs
+++ b/support-core-utils/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/support-dynamic-animation/source/Properties/AssemblyInfo.cs
+++ b/support-dynamic-animation/source/Properties/AssemblyInfo.cs
@@ -26,3 +26,4 @@ using Java.Interop;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/support-emoji-appcompat/source/Properties/AssemblyInfo.cs
+++ b/support-emoji-appcompat/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/support-emoji-bundled/source/Properties/AssemblyInfo.cs
+++ b/support-emoji-bundled/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/support-emoji/source/Properties/AssemblyInfo.cs
+++ b/support-emoji/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/support-fragment/source/Properties/AssemblyInfo.cs
+++ b/support-fragment/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/support-media-compat/source/Properties/AssemblyInfo.cs
+++ b/support-media-compat/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/support-tv-provider/source/Properties/AssemblyInfo.cs
+++ b/support-tv-provider/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/support-v13/source/Properties/AssemblyInfo.cs
+++ b/support-v13/source/Properties/AssemblyInfo.cs
@@ -21,3 +21,4 @@ using Android.App;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("1.0.0")]
+[assembly: Android.LinkerSafe]

--- a/support-v4/source/Properties/AssemblyInfo.cs
+++ b/support-v4/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/support-vector-drawable/source/Properties/AssemblyInfo.cs
+++ b/support-vector-drawable/source/Properties/AssemblyInfo.cs
@@ -20,3 +20,4 @@ using Android.App;
 // if desired. See the Mono documentation for more information about signing.
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]

--- a/transition/source/Properties/AssemblyInfo.cs
+++ b/transition/source/Properties/AssemblyInfo.cs
@@ -25,4 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
-
+[assembly: Android.LinkerSafe]

--- a/wear/source/Properties/AssemblyInfo.cs
+++ b/wear/source/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using Android.App;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+[assembly: Android.LinkerSafe]


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):
26.1.0.1

### Does this change any of the generated binding API's?
Nope

### Describe your contribution
I discovered there was some file size that could be spared from the
support library assemblies in release APKs by using the `Link all
assemblies` option. Since most Xamarin users will have the `Link SDK
only` option set, we can save most Xamarin developers some APK size by
setting up the `[assembly: LinkerSafe]` attribute in the support
libraries.

To get an idea on what this saves, I tested the default Xamarin.Forms
template in VS for Mac. I then upgraded to `TargetFrameworkVersion`
8.0, API 26, Xamarin.Forms 2.5.0, and 26.1.0.1 support libraries.

Before:
- Support libs: 5231104
- APK: 20948533

After `[assembly: LinkerSafe]`:
- Support libs: 2357248
- APK: 17312534

It appears this change saves ~3.6MB in APK file size in release mode
for the default Xamarin.Forms template. The app still seemed to work fine,
it appears we can just get this file size for free!

### Further details

Here is the results of `zipinfo` on the _before_ APK:
```
-rw----     1.0 fat    17920 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Arch.Core.Common.dll
-rw----     1.0 fat    19456 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Arch.Lifecycle.Common.dll
-rw----     1.0 fat    13824 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Arch.Lifecycle.Runtime.dll
-rw----     1.0 fat    33280 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.Animated.Vector.Drawable.dll
-rw----     1.0 fat   110080 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.Annotations.dll
-rw----     1.0 fat  1408512 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.Compat.dll
-rw----     1.0 fat   349696 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.Core.UI.dll
-rw----     1.0 fat   134144 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.Core.Utils.dll
-rw----     1.0 fat   403968 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.Design.dll
-rw----     1.0 fat   237568 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.Fragment.dll
-rw----     1.0 fat   432128 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.Media.Compat.dll
-rw----     1.0 fat   131072 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.Transition.dll
-rw----     1.0 fat    30208 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.v4.dll
-rw----     1.0 fat  1071616 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.v7.AppCompat.dll
-rw----     1.0 fat    30720 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.v7.CardView.dll
-rw----     1.0 fat   194048 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.v7.MediaRouter.dll
-rw----     1.0 fat    35840 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.v7.Palette.dll
-rw----     1.0 fat   554496 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.v7.RecyclerView.dll
-rw----     1.0 fat    22528 b- stor 17-Nov-15 08:44 assemblies/Xamarin.Android.Support.Vector.Drawable.dll
```

Here is the results of the _after_ APK with `[assembly: LinkerSafe]`:
```
-rw----     1.0 fat     5120 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Arch.Core.Common.dll
-rw----     1.0 fat    13824 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Arch.Lifecycle.Common.dll
-rw----     1.0 fat     5120 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Arch.Lifecycle.Runtime.dll
-rw----     1.0 fat     5632 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.Animated.Vector.Drawable.dll
-rw----     1.0 fat     5632 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.Annotations.dll
-rw----     1.0 fat   290816 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.Compat.dll
-rw----     1.0 fat   122368 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.Core.UI.dll
-rw----     1.0 fat    35840 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.Core.Utils.dll
-rw----     1.0 fat   403968 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.Design.dll
-rw----     1.0 fat   177664 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.Fragment.dll
-rw----     1.0 fat   157696 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.Media.Compat.dll
-rw----     1.0 fat   131072 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.Transition.dll
-rw----     1.0 fat     9728 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.v4.dll
-rw----     1.0 fat   409088 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.v7.AppCompat.dll
-rw----     1.0 fat    30720 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.v7.CardView.dll
-rw----     1.0 fat   194048 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.v7.MediaRouter.dll
-rw----     1.0 fat    35840 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.v7.Palette.dll
-rw----     1.0 fat   317952 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.v7.RecyclerView.dll
-rw----     1.0 fat     5120 b- stor 17-Nov-16 07:31 assemblies/Xamarin.Android.Support.Vector.Drawable.dll
```

Here is my `packages.config`:
```
<packages>
  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="monoandroid71" />
  <package id="Xam.Plugin.Connectivity" version="3.0.3" targetFramework="monoandroid71" />
  <package id="Xamarin.Android.Arch.Core.Common" version="1.0.0" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Arch.Lifecycle.Common" version="1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Arch.Lifecycle.Runtime" version="1.0.0" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.Annotations" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.Compat" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.Core.UI" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.Core.Utils" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.Design" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.Fragment" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.Media.Compat" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.Transition" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.v4" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.v7.AppCompat" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.v7.CardView" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.v7.MediaRouter" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.v7.Palette" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.v7.RecyclerView" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Android.Support.Vector.Drawable" version="26.1.0.1" targetFramework="monoandroid80" />
  <package id="Xamarin.Forms" version="2.5.0.77107" targetFramework="monoandroid71" />
</packages>
```