### PR TITLE
Adds bindings for android.arch.core:runtime:1.0.0

### DIFF
--- a/AndroidSupport.sln
+++ b/AndroidSupport.sln
@@ -77,6 +77,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core-Utils", "support-core-
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Content", "support-content\source\Content.csproj", "{F38426DC-DF6F-4FB3-8E9B-1F2E2BBEB554}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arch.Core.Runtime", "arch-core\runtime\source\Arch.Core.Runtime.csproj", "{4C9E1C1E-09C3-469C-B3C2-79651DF13871}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -231,10 +233,15 @@ Global
 		{F38426DC-DF6F-4FB3-8E9B-1F2E2BBEB554}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F38426DC-DF6F-4FB3-8E9B-1F2E2BBEB554}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F38426DC-DF6F-4FB3-8E9B-1F2E2BBEB554}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C9E1C1E-09C3-469C-B3C2-79651DF13871}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C9E1C1E-09C3-469C-B3C2-79651DF13871}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C9E1C1E-09C3-469C-B3C2-79651DF13871}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C9E1C1E-09C3-469C-B3C2-79651DF13871}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{4C9E1C1E-09C3-469C-B3C2-79651DF13870} = {3AC04D8E-9E4C-401F-AED5-239F226BF9C2}
 		{1489A4D8-8D13-4113-BD73-3025CDE3E3A0} = {3AC04D8E-9E4C-401F-AED5-239F226BF9C2}
 		{25CE44A9-FA51-4468-952F-21A13F066384} = {3AC04D8E-9E4C-401F-AED5-239F226BF9C2}
+		{4C9E1C1E-09C3-469C-B3C2-79651DF13871} = {3AC04D8E-9E4C-401F-AED5-239F226BF9C2}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The build script for this project uses [Cake](http://cakebuild.net).  To run the
 
 **Mac**:
 ```
-sh build.sh --target libs
+sh build.sh --target=libs
 ```
 
 **Windows (experimental support only)**:

--- a/arch-core/runtime/nuget/template.nuspec
+++ b/arch-core/runtime/nuget/template.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>Xamarin.Android.Arch.Core.Runtime</id>
+    <title>Xamarin Android Architecture Core - Runtime</title>
+    <version>$version$</version>
+    <authors>Xamarin Inc.</authors>
+    <owners>Xamarin Inc.</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Android Architecture Core - Runtime C# bindings for Xamarin</description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <projectUrl>https://github.com/xamarin/AndroidSupportComponents/</projectUrl>
+    <licenseUrl>https://github.com/xamarin/AndroidSupportComponents/blob/master/LICENSE.md</licenseUrl>
+    <iconUrl>https://raw.githubusercontent.com/xamarin/AndroidSupportComponents/master/icons/arch-core-common_128x128.png</iconUrl>
+    <dependencies>
+      
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="arch-core/common/nuget/Xamarin.Android.Arch.Core.Runtime.targets" target="build/MonoAndroid80" />
+
+    <file src="output/Xamarin.Android.Arch.Core.Runtime.dll" target="lib/MonoAndroid80" />
+
+    <file src="External-Dependency-Info.txt" target="THIRD-PARTY-NOTICES.txt" />
+  </files>
+</package>

--- a/arch-core/runtime/source/Arch.Core.Runtime.csproj
+++ b/arch-core/runtime/source/Arch.Core.Runtime.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{4C9E1C1E-09C3-469C-B3C2-79651DF13870}</ProjectGuid>
+    <ProjectGuid>{4C9E1C1E-09C3-469C-B3C2-79651DF13871}</ProjectGuid>
     <ProjectTypeGuids>{10368E6C-D01B-4462-8E8B-01FC667A7035};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>Android.Arch.Core.Runtime</RootNamespace>

--- a/arch-core/runtime/source/Arch.Core.Runtime.csproj
+++ b/arch-core/runtime/source/Arch.Core.Runtime.csproj
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4C9E1C1E-09C3-469C-B3C2-79651DF13870}</ProjectGuid>
+    <ProjectTypeGuids>{10368E6C-D01B-4462-8E8B-01FC667A7035};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Android.Arch.Core.Runtime</RootNamespace>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AssemblyName>Xamarin.Android.Arch.Core.Runtime</AssemblyName>
+    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
+    <!-- <SignAssembly>true</SignAssembly>
+    <DelaySign>true</DelaySign>
+    <AssemblyOriginatorKeyFile>publickey.snk</AssemblyOriginatorKeyFile> -->
+    <AndroidClassParser>class-parse</AndroidClassParser>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidLinkMode>None</AndroidLinkMode>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!--Docs URL Can be found here: http://dl-ssl.google.com/android/repository/repository-8.xml -->
+    <DroidDocPaths>..\..\..\docs\reference</DroidDocPaths>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Mono.Android" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <TransformFile Include="Transforms\EnumFields.xml" />
+    <TransformFile Include="Transforms\EnumMethods.xml" />
+    <TransformFile Include="Transforms\Metadata.xml" />
+    <TransformFile Include="..\..\..\Metadata.generated.xml">
+      <Link>Transforms\Metadata.generated.xml</Link>
+    </TransformFile>
+    <TransformFile Include="..\..\..\Metadata.common.xml">
+      <Link>Transforms\Metadata.common.xml</Link>
+    </TransformFile>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Additions\" />
+    <Folder Include="Jars\" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedJar Include="..\..\..\externals\arch-core\arch-core-runtime.aar">
+      <Link>arch-core-runtime.aar</Link>
+    </EmbeddedJar>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
+  
+</Project>

--- a/arch-core/runtime/source/Properties/AssemblyInfo.cs
+++ b/arch-core/runtime/source/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Android.App;
+
+// Information about this assembly is defined by the following attributes.
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("Xamarin.Android.Arch.Core.Runtime")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany ("Microsoft Corporation")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright ("Copyright © Microsoft Corporation")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.0")]
+
+// The following attributes are used to specify the signing key for the assembly,
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]
+
+[assembly: AssemblyMetadata ("BUILD_COMMIT",      "{BUILD_COMMIT}")]
+[assembly: AssemblyMetadata ("BUILD_NUMBER",    "{BUILD_NUMBER}")]
+[assembly: AssemblyMetadata ("BUILD_TIMESTAMP", "{BUILD_TIMESTAMP}")]
+
+[assembly: AssemblyInformationalVersion ("{NUGET_VERSION}")]
+
+[assembly: Android.LinkerSafe]

--- a/arch-core/runtime/source/Transforms/EnumFields.xml
+++ b/arch-core/runtime/source/Transforms/EnumFields.xml
@@ -1,0 +1,3 @@
+<enum-field-mappings>
+</enum-field-mappings>
+ 

--- a/arch-core/runtime/source/Transforms/EnumMethods.xml
+++ b/arch-core/runtime/source/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+<enum-method-mappings>
+</enum-method-mappings>

--- a/arch-core/runtime/source/Transforms/Metadata.xml
+++ b/arch-core/runtime/source/Transforms/Metadata.xml
@@ -1,0 +1,2 @@
+<metadata>
+</metadata>

--- a/build.cake
+++ b/build.cake
@@ -48,10 +48,12 @@ var COMPONENT_VERSION = "27.0.2.0";
 var AAR_VERSION = "27.0.2";
 
 var ARCH_CORE_COMMON_AAR_VERSION = "1.0.0";
+var ARCH_CORE_RUNTIME_AAR_VERSION = "1.0.0";
 var ARCH_LIFECYCLE_COMMON_AAR_VERSION = "1.0.3";
 var ARCH_LIFECYCLE_RUNTIME_AAR_VERSION = "1.0.3";
 
 var ARCH_CORE_COMMON_NUGET_VERSION = "1.0.0" + NUGET_PRE;
+var ARCH_CORE_RUNTIME_NUGET_VERSION = "1.0.0" + NUGET_PRE;
 var ARCH_LIFECYCLE_COMMON_NUGET_VERSION = "1.0.3" + NUGET_PRE;
 var ARCH_LIFECYCLE_RUNTIME_NUGET_VERSION = "1.0.3" + NUGET_PRE;
 
@@ -78,6 +80,7 @@ var USE_MSBUILD_ON_MAC = true;
 
 var ARTIFACTS = new [] {
 	new ArtifactInfo (ARCH_CORE_PKG_NAME, "common", "Xamarin.Android.Arch.Core.Common", ARCH_CORE_COMMON_AAR_VERSION, ARCH_CORE_COMMON_NUGET_VERSION, "1.0.0.0", true) { PathPrefix = "arch-core/" },
+	new ArtifactInfo (ARCH_CORE_PKG_NAME, "runtime", "Xamarin.Android.Arch.Core.Runtime", ARCH_CORE_RUNTIME_AAR_VERSION, ARCH_CORE_RUNTIME_NUGET_VERSION, "1.0.0.0") { PathPrefix = "arch-core/" },
 	new ArtifactInfo (ARCH_LIFECYCLE_PKG_NAME, "common", "Xamarin.Android.Arch.Lifecycle.Common", ARCH_LIFECYCLE_COMMON_AAR_VERSION, ARCH_LIFECYCLE_COMMON_NUGET_VERSION, "1.0.0.0", true) { PathPrefix = "arch-lifecycle/" },
 	new ArtifactInfo (ARCH_LIFECYCLE_PKG_NAME, "runtime", "Xamarin.Android.Arch.Lifecycle.Runtime", ARCH_LIFECYCLE_RUNTIME_AAR_VERSION, ARCH_LIFECYCLE_RUNTIME_NUGET_VERSION, "1.0.0.0") { PathPrefix = "arch-lifecycle/" },
 
@@ -289,6 +292,7 @@ Task ("externals")
 
 	// Fix naming for some of the arch libraries that have duplicate names of each other
 	MoveFile ("./externals/arch-core/common.jar", "./externals/arch-core/arch-core-common.jar");
+	MoveFile ("./externals/arch-core/runtime.aar", "./externals/arch-core/arch-core-runtime.aar");
 	MoveFile ("./externals/arch-lifecycle/common.jar", "./externals/arch-lifecycle/arch-lifecycle-common.jar");
 	MoveFile ("./externals/arch-lifecycle/runtime.aar", "./externals/arch-lifecycle/arch-lifecycle-runtime.aar");
 });


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):
26.1.0

### Does this change any of the generated binding API's?
Binding APIs for android.arch.core:runtime:1.0.0

### Describe your contribution
These changes provides binding APIs for android.arch.core:runtime:1.0.0.