### PR TITLE
[constraint-layout] Bump package to 2.0.0-alpha2 and add motionlayout fixup

### DIFF
--- a/constraint-layout/build.cake
+++ b/constraint-layout/build.cake
@@ -6,8 +6,8 @@
 var TARGET = Argument ("target", Argument ("t", "Default"));
 
 
-var NUGET_VERSION = "1.0.2.2";
-var AAR_VERSION = "1.0.2";
+var NUGET_VERSION = "2.0.0-alpha2";
+var AAR_VERSION = "2.0.0-alpha2";
 
 var CONSTRAINT_LAYOUT_URL = string.Format ("https://dl.google.com/dl/android/maven2/com/android/support/constraint/constraint-layout/{0}/constraint-layout-{0}.aar", AAR_VERSION);
 var CONSTRAINT_LAYOUT_SOLVER_URL = string.Format ("https://dl.google.com/dl/android/maven2/com/android/support/constraint/constraint-layout-solver/{0}/constraint-layout-solver-{0}.jar", AAR_VERSION);

--- a/constraint-layout/source/ConstraintLayout.csproj
+++ b/constraint-layout/source/ConstraintLayout.csproj
@@ -60,6 +60,10 @@
       <Project>{84FD66DF-C448-425E-860F-C0B076EED150}</Project>
       <Name>ConstraintLayoutSolver</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\support-compat\source\Compat.csproj">
+      <Project>{CA4194B2-8B2D-4C37-8790-C79C5803357A}</Project>
+      <Name>Compat</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <LibraryProjectZip Include="..\..\externals\constraint-layout.aar">

--- a/constraint-layout/source/Transforms/Metadata.xml
+++ b/constraint-layout/source/Transforms/Metadata.xml
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <metadata>
 	<attr path="/api/package[@name='android.support.constraint']" name="managedName">Android.Support.Constraints</attr>
+	<attr path="/api/package[@name='android.support.constraint.motion']" name="managedName">Android.Support.Constraints.Motion</attr>
 </metadata>


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0)

same as master, only constraint-layout is updated

### Does this change any of the generated binding API's?

Yes

### Describe your contribution

Generate a constraint-layout nuget referencing the current alpha of `ConstraintLayout` which also brings a preview of `MotionLayout`.
