### PR TITLE
[msbuild] make _VerifyXamarinAndroidSupportVersions incremental

### DIFF
--- a/source/com.android.support/support-annotations/merge.targets
+++ b/source/com.android.support/support-annotations/merge.targets
@@ -5,9 +5,16 @@
       AssemblyFile="Xamarin.Android.Support.BuildTasks.dll" 
       TaskName="Xamarin.Android.Support.BuildTasks.VerifyVersionsTask" />
 
+  <PropertyGroup>
+    <_SupportedVersionsStamp>$(IntermediateOutputPath)_VerifyXamarinAndroidSupportVersions.stamp</_SupportedVersionsStamp>
+  </PropertyGroup>
+
   <Target
     Name="_VerifyXamarinAndroidSupportVersions"
-    AfterTargets="ResolveAssemblyReferences">
+    Condition=" '$(DesignTimeBuild)' != 'True' "
+    AfterTargets="ResolveAssemblyReferences"
+    Inputs="$(MSBuildProjectFile);$(AndroidManifest)"
+    Outputs="$(_SupportedVersionsStamp)">
 
     <PropertyGroup>
       <XamarinAndroidSupportSkipVerifyVersions Condition="'$(XamarinAndroidSupportSkipVerifyVersions)'==''">false</XamarinAndroidSupportSkipVerifyVersions>
@@ -23,6 +30,14 @@
         DesignTimeBuild="$(DesignTimeBuild)"
         >
     </VerifyVersionsTask>
+
+    <Touch
+        AlwaysCreate="True"
+        Files="$(_SupportedVersionsStamp)"
+    />
+    <ItemGroup>
+      <FileWrites Include="$(_SupportedVersionsStamp)" />
+    </ItemGroup>
 
   </Target>
     


### PR DESCRIPTION
### Support Libraries Version

28.x

### Does this change any of the generated binding API's?

No

### Describe your contribution

When reviewing build logs from 2019 GA, I noticed an MSBuild target
from the support libraries taking some time:

    377 ms  _VerifyXamarinAndroidSupportVersions       1 calls

In a build with no changes, it was the 5th longest duration:

      463 ms  _SetLatestTargetFrameworkVersion                1 calls
      554 ms  _ResolveAssemblies                              1 calls
      606 ms  _GetProjectReferenceTargetFrameworkProperties   2 calls
      682 ms  ResolveProjectReferences                        2 calls

*NOTE: you can do `msbuild foo.csproj /clp:performancesummary` for
this breakdown.*

It looks like there are a couple things we can improve here:

1. This target runs on design-time builds.
2. This target always runs on every build, even when there is no
   changes.

No. 1 we can add a `Condition`, as I don't think it is worth the build
time--DTBs are supposed to be as quick as possible. I don't think it's
needed during DTBs at all?

For No. 2, we can also skip this target after the first build unless:

* The project file changes.
* The `AndroidManifest.xml` changes.

So I setup a simple `.stamp` file, that will allow these target to
skip unless one of the inputs changes.

Details about how we do this in Xamarin.Android here:

https://github.com/xamarin/xamarin-android/blob/master/Documentation/guides/MSBuildBestPractices.md#stamp-files
