### PR TITLE
Move the targets files into sub-folders

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -99,6 +99,14 @@ Task("binderate")
 
 	StartProcess("dotnet", "./util/binderator/android-binderator.dll --config=\""
 		+ MakeAbsolute(configFile).FullPath + "\" --basepath=\"" + MakeAbsolute(basePath).FullPath + "\"");
+
+	// format the targets file so they are pretty in the package
+	var targetsFiles = GetFiles("generated/**/*.targets");
+	var xmlns = (XNamespace)"http://schemas.microsoft.com/developer/msbuild/2003";
+	foreach (var targets in targetsFiles) {
+		var xdoc = XDocument.Load(targets.FullPath);
+		xdoc.Save(targets.FullPath);
+	}
 });
 
 Task("libs")

--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -1,7 +1,7 @@
 ﻿@using System.Linq
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid90</TargetFrameworks>
+    <TargetFramework>MonoAndroid90</TargetFramework>
     <IsBindingProject>true</IsBindingProject>
     @if (!string.IsNullOrEmpty(Model.AssemblyName)) {
     <AssemblyName>@(Model.AssemblyName)</AssemblyName>

--- a/source/AndroidXTargets.cshtml
+++ b/source/AndroidXTargets.cshtml
@@ -21,7 +21,7 @@
   <ItemGroup>
     @foreach (var art in @Model.MavenArtifacts) {
       if (art.ProguardFile != null) {
-    <ProguardConfiguration Include="$(MSBuildThisFileDirectory)..\proguard\proguard.txt">
+    <ProguardConfiguration Include="$(MSBuildThisFileDirectory)..\..\proguard\proguard.txt">
       <AndroidXSkipAndroidXMigration>true</AndroidXSkipAndroidXMigration>
     </ProguardConfiguration>
       }
@@ -37,11 +37,11 @@
       }
 
       if (art.MavenArtifactPackaging == "aar") {
-    <AndroidAarLibrary Include="$(MSBuildThisFileDirectory)..\aar\@(art.MavenGroupId).@(art.MavenArtifactId).aar">
+    <AndroidAarLibrary Include="$(MSBuildThisFileDirectory)..\..\aar\@(art.MavenGroupId).@(art.MavenArtifactId).aar">
       <AndroidXSkipAndroidXMigration>true</AndroidXSkipAndroidXMigration>
     </AndroidAarLibrary>
       } else {
-    <AndroidJavaLibrary Include="$(MSBuildThisFileDirectory)..\jar\@(art.MavenGroupId).@(art.MavenArtifactId).jar">
+    <AndroidJavaLibrary Include="$(MSBuildThisFileDirectory)..\..\jar\@(art.MavenGroupId).@(art.MavenArtifactId).jar">
       <AndroidXSkipAndroidXMigration>true</AndroidXSkipAndroidXMigration>
     </AndroidJavaLibrary>
       }

--- a/source/androidx.multidex/multidex/merge.targets
+++ b/source/androidx.multidex/multidex/merge.targets
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(AndroidEnableMultiDex)' == 'true'">
-    <AndroidAarLibrary Include="$(MSBuildThisFileDirectory)..\aar\androidx.multidex.multidex.aar">
+    <AndroidAarLibrary Include="$(MSBuildThisFileDirectory)..\..\aar\androidx.multidex.multidex.aar">
       <AndroidXSkipAndroidXMigration>true</AndroidXSkipAndroidXMigration>
     </AndroidAarLibrary>
   </ItemGroup>


### PR DESCRIPTION
Move the targets files into sub-folders:
 - this will prevent installation into unsupported projects
 - the TargetFramework is not set for Pack in multitargeting packages, so just use a normal, single target framework
 - throw in an extra pretty print for the targets so users don't think we are animals in the xml files :)
