### PR TITLE
Fix the designer for the separate .jar files

### DIFF
--- a/source/androidx.annotation/annotation/merge.targets
+++ b/source/androidx.annotation/annotation/merge.targets
@@ -20,5 +20,23 @@
     </VerifyVersionsTask>
 
   </Target> -->
-    
+
+    <!--
+    ***************************************************************************
+    * GET EXTRA LIBRARY LOCATIONS FOR DESIGNER
+    * This target will make sure that the included .jar files are available to
+    * the designer. 
+    * TODO: REMOVE THIS AFTER THE PR IS MERGED
+    *       https://github.com/xamarin/xamarin-android/pull/3418
+    ***************************************************************************
+    -->
+    <Target Name="_AndroidXGetExtraLibraryLocationsForDesigner"
+            AfterTargets="GetExtraLibraryLocationsForDesigner">
+        <ItemGroup>
+            <ExtraJarLocation Include="@(AndroidJavaLibrary)">
+                <Source>AndroidJavaLibrary</Source>
+            </ExtraJarLocation>
+        </ItemGroup>
+    </Target>
+
 </Project>


### PR DESCRIPTION
Fix the designer for the separate .jar files from the .targets files. This is a temporary workaround until https://github.com/xamarin/xamarin-android/pull/3418 is merged.
